### PR TITLE
Updated to new mod registry format

### DIFF
--- a/load_order_stellaris24.py
+++ b/load_order_stellaris24.py
@@ -34,7 +34,13 @@ def getModList(data):
             mod = Mod(key, name, modId)
             modList.append(mod)
         except KeyError:
-            print('key not found in ', key, data)
+            try:
+                name = data['displayName']
+                modId = data['steamId']
+                mod = Mod(key, name, modId)
+                modList.append(mod)
+            except KeyError:
+                print('key not found in ', key, data)
     modList.sort(key=sortedKey, reverse=True)
     return modList
 


### PR DESCRIPTION
New mod registry format uses "steamId" instead of "gameRegistryId" (however the old format is still compatible)